### PR TITLE
Line Endings Fix for Docker Entrypoint Script

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,11 +10,9 @@ WORKDIR /app
 
 # Install system dependencies (e.g., for compiling any Python dependencies)
 RUN apt-get update && \
-    apt-get install -y build-essential libpq-dev && \
+    apt-get install -y build-essential libpq-dev dos2unix && \
     apt-get clean
 
-
-    
 # Copy and install Python dependencies
 COPY requirements.txt /app/
 RUN pip install --upgrade pip && \
@@ -23,11 +21,12 @@ RUN pip install --upgrade pip && \
 # Copy the Django project files
 COPY . /app/
 
-
 # Copy the entrypoint script to the image
 COPY entrypoint.sh /app/
+# Convert entrypoint.sh to use LF line endings
+RUN dos2unix /app/entrypoint.sh
 # Make the entrypoint script executable
-RUN chmod +x ./entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 # Set the port
 EXPOSE 8000
@@ -35,12 +34,5 @@ EXPOSE 8000
 # Entrypoint script
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-
-# Expose port 8000 for the Django app
-EXPOSE 8000
-
 # Start the application using Gunicorn
-
 CMD ["gunicorn", "backend.wsgi:application", "--bind", "0.0.0.0:8000"]
-
-


### PR DESCRIPTION
Problem:
Docker container fails to execute entrypoint.sh with error: exec /app/entrypoint.sh: no such file or directory Caused by Windows CRLF line endings being incompatible with Linux containers

Solution:
Added dos2unix conversion in Dockerfile to ensure Linux-compatible line endings: