### PR TITLE
Added NGINX configuration to properly handle client-side routing in t…

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,6 +26,9 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy build output from builder stage to Nginx's html directory
 COPY --from=builder /app/dist /usr/share/nginx/html
 
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 # Expose port 80
 EXPOSE 80
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Handle all routes for single-page application
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
…he React application, fixing the /settings route and other client-side routes.

The issue occurred because NGINX wasn't configured to handle client-side routing, causing routes like /settings to return 404 errors. This fix implements proper NGINX configuration to:

Forward all requests to index.html
Allow React Router to handle client-side routing
Maintain proper SPA (Single Page Application) behavior